### PR TITLE
feat(stories): add bikram sambat calendar and picker input stories

### DIFF
--- a/src/stories/components/Form/DatePickerInput.stories.jsx
+++ b/src/stories/components/Form/DatePickerInput.stories.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {action} from 'storybook/actions';
+
+import DatePickerInput from '@ra/components/Form/DatePickerInput';
+
+export const Story = () => (
+    <div style={{maxWidth: 320}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Default (AD) mode: a Gregorian date picker. onChange emits an ISO value (yyyy-mm-dd).
+        </p>
+        <DatePickerInput
+            name="adDate"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+Story.storyName = 'Default (AD)';
+
+export const NepaliStory = () => (
+    <div style={{maxWidth: 320}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Nepali (BS) mode: the user sees and enters Bikram Sambat, but onChange still emits the ISO
+            (AD) value. Try language="ne" for Nepali script and digits.
+        </p>
+        <DatePickerInput
+            name="bsDate"
+            mode="nepali"
+            language="ne"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+NepaliStory.storyName = 'Nepali (BS)';
+
+export const ToggleStory = () => (
+    <div style={{maxWidth: 320}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Toggle mode: an AD/BS switcher sits on the input row (always visible), so the user can
+            flip the displayed calendar system without opening the picker. The emitted value stays
+            ISO/AD regardless of display.
+        </p>
+        <DatePickerInput
+            name="toggleDate"
+            mode="toggle"
+            language="ne"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+ToggleStory.storyName = 'Toggle (AD/BS)';
+
+export const BoundedStory = () => (
+    <div style={{maxWidth: 320}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Bounds are ISO too. Bounded between 2024-04-13 and 2024-07-15; out-of-range dates are
+            disabled, and this works in AD or BS display.
+        </p>
+        <DatePickerInput
+            name="boundedDate"
+            mode="toggle"
+            minimumDate="2024-04-13"
+            maximumDate="2024-07-15"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+BoundedStory.storyName = 'Bounded (ISO min/max)';
+
+export const CalendarDropdownsStory = () => (
+    <div style={{maxWidth: 320}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Year and month quick-jump dropdowns forwarded through calendarProps.
+        </p>
+        <DatePickerInput
+            name="dropdownDate"
+            mode="toggle"
+            calendarProps={{enableYearDropdown: true, enableMonthDropdown: true}}
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+CalendarDropdownsStory.storyName = 'Forwarded calendar dropdowns';
+
+export const DisabledStory = () => (
+    <div style={{maxWidth: 320}}>
+        <DatePickerInput
+            name="disabledDate"
+            disabled
+            defaultValue="2024-04-13"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+DisabledStory.storyName = 'Disabled';
+
+export default {
+    title: 'Form/Date Picker Input',
+    component: DatePickerInput,
+};

--- a/src/stories/components/Form/DateTimePickerInput.stories.jsx
+++ b/src/stories/components/Form/DateTimePickerInput.stories.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import {action} from 'storybook/actions';
+
+import DateTimePickerInput from '@ra/components/Form/DateTimePickerInput';
+
+export const Story = () => (
+    <div style={{maxWidth: 340}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Default (AD) mode: Gregorian calendar plus the stepped time list. onChange emits an ISO
+            datetime (yyyy-mm-ddThh:mm, with the T).
+        </p>
+        <DateTimePickerInput
+            name="adDateTime"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+Story.storyName = 'Default (AD)';
+
+export const NepaliStory = () => (
+    <div style={{maxWidth: 340}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Nepali (BS) mode: the user sees/enters Bikram Sambat date + time, but onChange still emits
+            the ISO (AD) datetime.
+        </p>
+        <DateTimePickerInput
+            name="bsDateTime"
+            mode="nepali"
+            language="ne"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+NepaliStory.storyName = 'Nepali (BS)';
+
+export const ToggleStory = () => (
+    <div style={{maxWidth: 340}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Toggle mode: an AD/BS switcher on the input row (always visible) flips the displayed
+            calendar system without opening the picker. The emitted value stays ISO/AD.
+        </p>
+        <DateTimePickerInput
+            name="toggleDateTime"
+            mode="toggle"
+            language="ne"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+ToggleStory.storyName = 'Toggle (AD/BS)';
+
+export const BoundedStory = () => (
+    <div style={{maxWidth: 340}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            ISO datetime bounds. Bounded from 2024-04-13T09:00 to 2024-07-15T17:00; the time limit
+            applies only on the boundary dates and out-of-window times are greyed in the list.
+        </p>
+        <DateTimePickerInput
+            name="boundedDateTime"
+            mode="toggle"
+            minimumDate="2024-04-13T09:00"
+            maximumDate="2024-07-15T17:00"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+BoundedStory.storyName = 'Bounded (ISO min/max)';
+
+export const NativeTimeStory = () => (
+    <div style={{maxWidth: 340}}>
+        <p style={{marginTop: 0, fontSize: 13, color: '#666'}}>
+            Native time mode uses the browser time input (no per-value greying), with the enforcement
+            backstop still rejecting out-of-window times.
+        </p>
+        <DateTimePickerInput
+            name="nativeDateTime"
+            timeMode="native"
+            minimumDate="2024-04-13T09:00"
+            maximumDate="2024-07-15T17:00"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+NativeTimeStory.storyName = 'Native time mode';
+
+export const DisabledStory = () => (
+    <div style={{maxWidth: 340}}>
+        <DateTimePickerInput
+            name="disabledDateTime"
+            disabled
+            defaultValue="2024-04-13T14:30"
+            onChange={action('changed')}
+        />
+    </div>
+);
+
+DisabledStory.storyName = 'Disabled';
+
+export default {
+    title: 'Form/Date Time Picker Input',
+    component: DateTimePickerInput,
+};

--- a/src/stories/components/NepaliCalendar.stories.jsx
+++ b/src/stories/components/NepaliCalendar.stories.jsx
@@ -1,0 +1,89 @@
+import React, {useState} from 'react';
+import {action} from 'storybook/actions';
+
+import Calendar from '@ra/components/Calendar';
+import {
+    convertBikramSambatToGregorian,
+    convertGregorianToBikramSambat,
+    formatBikramSambatDate,
+    getDaysInBikramSambatMonth,
+    getTodayBikramSambatDate,
+} from '@ra/utils/date';
+
+const SelectableCalendar = props => {
+    const [selectedDate, setSelectedDate] = useState(null);
+
+    const handleDateChange = date => {
+        setSelectedDate(date);
+        action('changed')(date);
+    };
+
+    return (
+        <div style={{maxWidth: 320}}>
+            <Calendar system="nepali" value={selectedDate} onChange={handleDateChange} {...props} />
+        </div>
+    );
+};
+
+export const Story = () => <SelectableCalendar />;
+
+Story.storyName = 'Default';
+
+export const BoundedStory = () => {
+    const today = getTodayBikramSambatDate();
+
+    return (
+        <SelectableCalendar
+            minimumDate={{year: today.year, month: 1, day: 1}}
+            maximumDate={{
+                year: today.year,
+                month: 12,
+                day: getDaysInBikramSambatMonth(today.year, 12),
+            }}
+        />
+    );
+};
+
+BoundedStory.storyName = 'Bounded Min/Max (Current BS Year)';
+
+export const NepaliLanguageStory = () => <SelectableCalendar language="ne" />;
+
+NepaliLanguageStory.storyName = 'Nepali Language (implies Nepali digits)';
+
+export const DropdownNavigationStory = () => (
+    <SelectableCalendar enableYearDropdown enableMonthDropdown />
+);
+
+DropdownNavigationStory.storyName = 'Year/Month Quick-Jump Dropdowns';
+
+export const ConversionStory = () => {
+    const newYearBikramSambat = {year: 2081, month: 1, day: 1};
+    const newYearGregorian = convertBikramSambatToGregorian(newYearBikramSambat);
+    const roundTripBikramSambat = convertGregorianToBikramSambat(newYearGregorian);
+    const todayBikramSambat = getTodayBikramSambatDate();
+
+    return (
+        <div style={{display: 'grid', gridTemplateColumns: 'auto auto', gap: '8px 24px', width: 'fit-content'}}>
+            <span>BS 2081-01-01 in AD</span>
+            <strong>{newYearGregorian.toDateString()}</strong>
+            <span>AD {newYearGregorian.toDateString()} back in BS</span>
+            <strong>{formatBikramSambatDate(roundTripBikramSambat)}</strong>
+            <span>Today ({new Date().toDateString()}) in BS</span>
+            <strong>{formatBikramSambatDate(todayBikramSambat, 'MMMM D, YYYY')}</strong>
+            <span>Today in BS (Nepali)</span>
+            <strong>
+                {formatBikramSambatDate(todayBikramSambat, 'MMMM D, YYYY', {
+                    language: 'ne',
+                    useNepaliDigits: true,
+                })}
+            </strong>
+        </div>
+    );
+};
+
+ConversionStory.storyName = 'BS/AD Conversion Example';
+
+export default {
+    title: 'Components/Nepali Calendar',
+    component: Calendar,
+};


### PR DESCRIPTION
- [x] add nepali calendar stories: default, bounded, nepali language, and a bs/ad demo.
- [x] add datepickerinput stories: ad, nepali, toggle, bounded, dropdowns, and disabled.
- [x] add datetimepickerinput stories: ad, nepali, toggle, bounded, native time, disabled.