### PR TITLE
feat(stories): add table stories with column sorting

### DIFF
--- a/src/stories/components/Table/Table.stories.jsx
+++ b/src/stories/components/Table/Table.stories.jsx
@@ -1,0 +1,390 @@
+import React, {useCallback, useState} from 'react';
+import {action} from 'storybook/actions';
+
+import Table from '@ra/components/Table';
+import HierarchicalTable from '@ra/components/Table/Hierarchical';
+import Pagination from '@ra/components/Pagination';
+import SelectInput from '@ra/components/Form/SelectInput';
+
+import styles from './styles.module.scss';
+
+const columns = [
+    {
+        Header: 'Name',
+        accessor: 'name',
+    },
+    {
+        Header: 'Place',
+        accessor: 'place',
+    },
+    {
+        Header: 'Animal',
+        accessor: 'animal',
+    },
+    {
+        Header: 'Thing',
+        accessor: 'thing',
+    },
+];
+
+const data = [
+    {name: 'Alice', place: 'Wonderland', animal: 'Cheshire Cat', thing: 'Magic'},
+    {name: 'Bob', place: 'Builderland', animal: 'Dog', thing: 'Tools'},
+    {name: 'Charlie', place: 'Chocolate Factory', animal: 'Oompa Loompa', thing: 'Chocolate'},
+    {name: 'Dora', place: 'Explorerland', animal: 'Monkey', thing: 'Backpack'},
+    {name: 'Eve', place: 'Eden', animal: 'Snake', thing: 'Apple'},
+    {name: 'Frodo', place: 'Shire', animal: 'Hobbit', thing: 'Ring'},
+    {name: 'Gandalf', place: 'Middle-earth', animal: 'Eagle', thing: 'Staff'},
+    {name: 'Harry', place: 'Hogwarts', animal: 'Owl', thing: 'Wand'},
+    {name: 'Indiana', place: 'Adventureland', animal: 'Snake', thing: 'Whip'},
+    {name: 'Jack', place: 'Pirate Cove', animal: 'Parrot', thing: 'Compass'},
+    {name: 'Katniss', place: 'District 12', animal: 'Mockingjay', thing: 'Bow'},
+    {name: 'Legolas', place: 'Mirkwood', animal: 'Horse', thing: 'Bow'},
+    {name: 'Mickey', place: 'Disneyland', animal: 'Mouse', thing: 'Ears'},
+    {name: 'Nemo', place: 'Coral Reef', animal: 'Clownfish', thing: 'Sea Anemone'},
+    {name: 'Olaf', place: 'Arendelle', animal: 'Snowman', thing: 'Carrot Nose'},
+    {name: 'Peter', place: 'Neverland', animal: 'Fairy', thing: 'Pixie Dust'},
+    {name: 'Quasimodo', place: 'Notre Dame', animal: 'Bell', thing: 'Hunchback'},
+    {name: 'Rapunzel', place: 'Tower', animal: 'Chameleon', thing: 'Hair'},
+    {name: 'Simba', place: 'Pride Rock', animal: 'Lion', thing: 'Crown'},
+    {name: 'Tiana', place: 'New Orleans', animal: 'Frog', thing: 'Lily Pad'},
+];
+
+const nameExtractor = item => item.name;
+
+export const Story = storyArgs => {
+    const [page, setPage] = useState(1);
+    const [maxRows, setMaxRows] = useState(10);
+    const [selectedItems, setSelectedItems] = useState([]);
+
+    const handleChangePage = useCallback(({currentPage}) => {
+        setPage(currentPage);
+    }, []);
+
+    const handleMaxRowsChange = useCallback(({option}) => {
+        if(option) {
+            setMaxRows(option);
+            setPage(1);
+        } else {
+            setMaxRows(10);
+        }
+    }, []);
+
+    const handleSelectedItemsChange = useCallback(items => {
+        action('Selected Items')(items.map(nameExtractor));
+        setSelectedItems(items);
+    }, []);
+
+    return (
+        <div className={styles.container}>
+            <Table
+                className={styles.table}
+                columns={columns}
+                data={data}
+                page={page}
+                maxRows={maxRows}
+                keyExtractor={nameExtractor}
+                selectedItems={selectedItems}
+                dataClassName={styles.tableData}
+                headerItemClassName={styles.tableHeaderItem}
+                onSelectedItemsChange={handleSelectedItemsChange}
+                {...storyArgs}
+            />
+            <div className={styles.tableControls}>
+                <div className={styles.rowsInfo}>
+                    Show
+                    <SelectInput
+                        options={[10, 20, 50]}
+                        keyExtractor={item => item}
+                        valueExtractor={item => String(item)}
+                        onChange={handleMaxRowsChange}
+                        value={maxRows}
+                        clearable={false}
+                        searchable={false}
+                    />
+                    rows
+                </div>
+                <Pagination
+                    pageLimit={maxRows}
+                    pageNeighbours={1}
+                    totalRecords={data.length}
+                    onChange={handleChangePage}
+                />
+            </div>
+        </div>
+    );
+};
+
+Story.args = {
+    selectable: false,
+};
+
+Story.argTypes = {
+    selectable: {
+        description: 'Whether rows are selectable',
+        control: 'boolean',
+        defaultValue: false,
+    },
+};
+
+Story.storyName = 'Table';
+
+const employees = [
+    {
+        id: 'employee-1',
+        name: 'Rajesh Shrestha',
+        score: 82,
+        department: {title: 'Engineering'},
+        priority: 'Medium',
+        priorityRank: 2,
+    },
+    {
+        id: 'employee-2',
+        name: 'anita gurung',
+        score: 91,
+        department: {title: 'Design'},
+        priority: 'Low',
+        priorityRank: 1,
+    },
+    {
+        id: 'employee-3',
+        name: 'Bibek Thapa',
+        score: 7,
+        department: {title: 'Operations'},
+        priority: 'Critical',
+        priorityRank: 4,
+    },
+    {
+        id: 'employee-4',
+        name: 'Chandra Adhikari',
+        score: 64,
+        department: {title: 'Engineering'},
+        priority: 'High',
+        priorityRank: 3,
+    },
+    {
+        id: 'employee-5',
+        name: 'Deepa Karki',
+        score: 100,
+        department: {title: 'Research'},
+        priority: 'Low',
+        priorityRank: 1,
+    },
+    {
+        id: 'employee-6',
+        name: 'Elina Maharjan',
+        score: 45,
+        department: {title: 'Design'},
+        priority: 'Critical',
+        priorityRank: 4,
+    },
+];
+
+const idExtractor = item => item.id;
+
+const sortableColumns = [
+    {Header: 'Name', accessor: 'name', sortable: true},
+    {Header: 'Score', accessor: 'score', sortable: true},
+    {Header: 'Priority', accessor: 'priority'},
+];
+
+const deepFieldColumns = [
+    {Header: 'Name', accessor: 'name', sortable: true},
+    {
+        Header: 'Department',
+        accessor: 'department.title',
+        sortable: true,
+        sortAccessor: item => item.department.title,
+    },
+    {
+        Header: 'Priority',
+        accessor: 'priority',
+        sortable: true,
+        sortComparator: (firstItem, secondItem) => firstItem.priorityRank - secondItem.priorityRank,
+    },
+];
+
+const renderDeepFieldDataItem = ({item, column}) => {
+    if(column.accessor === 'department.title') {
+        return item.department.title;
+    }
+    return item[column.accessor];
+};
+
+const EmployeeTable = tableProps => (
+    <div className={styles.container}>
+        <Table
+            className={styles.table}
+            data={employees}
+            keyExtractor={idExtractor}
+            dataClassName={styles.tableData}
+            headerItemClassName={styles.tableHeaderItem}
+            {...tableProps}
+        />
+    </div>
+);
+
+export const SortableColumnsStory = () => (
+    <EmployeeTable columns={sortableColumns} onSortChange={action('sort changed')} />
+);
+
+SortableColumnsStory.storyName = 'Sortable Columns (Priority Left Unsorted)';
+
+export const DefaultSortStory = () => (
+    <EmployeeTable
+        columns={sortableColumns}
+        defaultSort={{accessor: 'score', direction: 'desc'}}
+        onSortChange={action('sort changed')}
+    />
+);
+
+DefaultSortStory.storyName = 'Default Sort (Score Descending)';
+
+export const ControlledSortStory = () => {
+    const [sort, setSort] = useState({accessor: 'name', direction: 'asc'});
+
+    const handleSortChange = useCallback(nextSort => {
+        action('sort changed')(nextSort);
+        setSort(nextSort);
+    }, []);
+
+    return (
+        <div>
+            <p className={styles.note}>
+                The story owns the sort state:{' '}
+                {sort ? `${sort.accessor} ${sort.direction}` : 'unsorted'}
+            </p>
+            <EmployeeTable columns={sortableColumns} sort={sort} onSortChange={handleSortChange} />
+        </div>
+    );
+};
+
+ControlledSortStory.storyName = 'Controlled Sort';
+
+export const ManualSortStory = () => {
+    const [sort, setSort] = useState(null);
+
+    const handleSortChange = useCallback(nextSort => {
+        action('sort requested')(nextSort);
+        setSort(nextSort);
+    }, []);
+
+    return (
+        <div>
+            <p className={styles.note}>
+                With manualSort the server owns the order, so rows keep their original position
+                while the indicator and onSortChange still report the requested sort.
+            </p>
+            <EmployeeTable
+                manualSort
+                columns={sortableColumns}
+                sort={sort}
+                onSortChange={handleSortChange}
+            />
+        </div>
+    );
+};
+
+ManualSortStory.storyName = 'Manual Sort (Indicator Only)';
+
+export const CustomSortStory = () => (
+    <EmployeeTable
+        columns={deepFieldColumns}
+        renderDataItem={renderDeepFieldDataItem}
+        onSortChange={action('sort changed')}
+    />
+);
+
+CustomSortStory.storyName = 'Custom sortAccessor and sortComparator';
+
+const orgTree = [
+    {
+        id: 'eng',
+        name: 'Engineering',
+        score: 75,
+        level: 0,
+        children: [
+            {
+                id: 'eng-backend',
+                name: 'Backend Team',
+                score: 60,
+                level: 1,
+                children: [
+                    {id: 'eng-backend-zara', name: 'Zara Sharma', score: 88, level: 2},
+                    {id: 'eng-backend-amit', name: 'Amit Rai', score: 45, level: 2},
+                ],
+            },
+            {
+                id: 'eng-frontend',
+                name: 'Frontend Team',
+                score: 95,
+                level: 1,
+                children: [
+                    {id: 'eng-frontend-priya', name: 'Priya Basnet', score: 67, level: 2},
+                ],
+            },
+        ],
+    },
+    {
+        id: 'design',
+        name: 'Design',
+        score: 90,
+        level: 0,
+        children: [
+            {
+                id: 'design-ux',
+                name: 'UX Team',
+                score: 80,
+                level: 1,
+                children: [
+                    {id: 'design-ux-nikhil', name: 'Nikhil Gurung', score: 70, level: 2},
+                    {id: 'design-ux-bikash', name: 'Bikash Karki', score: 40, level: 2},
+                ],
+            },
+            {
+                id: 'design-product',
+                name: 'Product Team',
+                score: 55,
+                level: 1,
+                children: [
+                    {id: 'design-product-sita', name: 'Sita Poudel', score: 99, level: 2},
+                ],
+            },
+        ],
+    },
+];
+
+const orgTreeColumns = [
+    {Header: 'Name', accessor: 'name', sortable: true},
+    {Header: 'Score', accessor: 'score', sortable: true},
+];
+
+const renderOrgTreeDataItem = ({item, column}) => item[column.accessor];
+
+export const HierarchicalSortStory = () => (
+    <div className={styles.container}>
+        <p className={styles.note}>
+            Sorting is hierarchy-aware: clicking a header reorders siblings at every
+            depth (the two departments, the teams within a department, the members
+            within a team) while each node stays under its own parent.
+        </p>
+        <HierarchicalTable
+            className={styles.table}
+            columns={orgTreeColumns}
+            data={orgTree}
+            keyExtractor={idExtractor}
+            hierarchyOptions={{initialExpandedLevel: 2}}
+            renderDataItem={renderOrgTreeDataItem}
+            dataClassName={styles.tableData}
+            headerItemClassName={styles.tableHeaderItem}
+            onSortChange={action('sort changed')}
+        />
+    </div>
+);
+
+HierarchicalSortStory.storyName = 'Hierarchical Sort (Siblings Reordered Per Level)';
+
+export default {
+    title: 'Components/Table',
+    component: Table,
+};

--- a/src/stories/components/Table/styles.module.scss
+++ b/src/stories/components/Table/styles.module.scss
@@ -1,0 +1,36 @@
+.note {
+    max-width: 40rem;
+    margin: 0 0 1rem;
+    color: var(--color-text-secondary, #55606d);
+}
+
+.container {
+    padding-bottom: 5rem;
+
+    .table {
+        border-collapse: collapse;
+
+        .tableData {
+            border: none;
+        }
+
+        .tableHeaderItem {
+            border: none;
+            text-align: left;
+        }
+    }
+
+    .tableControls {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-top: 1rem;
+        justify-content: space-between;
+
+        .rowsInfo {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+    }
+}


### PR DESCRIPTION
- [x] add paginated, selectable Table story with row-count control.
- [x] add sortable columns story leaving one column unsorted.
- [x] add defaultSort and controlled sort with onSortChange stories.
- [x] add manualSort story and sortAccessor/sortComparator story for deep fields.
- [x] add HierarchicalTable story showing sibling-only reordering at every tree depth.